### PR TITLE
[GEN-689] do not bump positions of indels for vcfs

### DIFF
--- a/standardize_mutation_data.py
+++ b/standardize_mutation_data.py
@@ -1308,21 +1308,21 @@ def resolve_vcf_variant_allele_data(vcf_data, maf_data):
     variant_class = ""
 
     if (ref_allele != "N" and ref_allele != "") and alt_allele != "":
-        # indels from vcf need to be shifted by one nucleotide and start position needs to be incremented by one
-        if ref_allele[0] == alt_allele[0] and ref_allele != alt_allele:
-            # shift ref allele and alt allele by one nucleotide, set as "-" if len == 1
-            if len(ref_allele) == 1:
-                ref_allele = "-"
-            else:
-                ref_allele = ref_allele[1:]
-            if len(alt_allele) == 1:
-                alt_allele = "-"
-            else:
-                alt_allele = alt_allele[1:]
+        # # indels from vcf need to be shifted by one nucleotide and start position needs to be incremented by one
+        # if ref_allele[0] == alt_allele[0] and ref_allele != alt_allele:
+        #     # shift ref allele and alt allele by one nucleotide, set as "-" if len == 1
+        #     if len(ref_allele) == 1:
+        #         ref_allele = "-"
+        #     else:
+        #         ref_allele = ref_allele[1:]
+        #     if len(alt_allele) == 1:
+        #         alt_allele = "-"
+        #     else:
+        #         alt_allele = alt_allele[1:]
 
-            # fix start position value
-            # if start_pos != "":
-            #     start_pos = str(int(start_pos) + 1)
+        #     # fix start position value
+        #     if start_pos != "":q
+        #         start_pos = str(int(start_pos) + 1)
 
         # resolve variant type, end position, and variant class
         variant_type = resolve_vcf_variant_type(ref_allele, alt_allele)

--- a/standardize_mutation_data.py
+++ b/standardize_mutation_data.py
@@ -457,13 +457,13 @@ def resolve_end_position(data, start_pos, variant_type, ref_allele):
         if column in data.keys():
             end_pos = process_datum(data[column])
             break
-    # # if insertion then end pos is start pos + 1
-    # if variant_type == "INS" or ref_allele == "-":
-    #     try:
-    #         end_pos = str(int(start_pos)+1)
-    #     except ValueError:
-    #         print(data)
-    #         sys.exit(2)
+    # if insertion then end pos is start pos + 1
+    if variant_type == "INS" or ref_allele == "-":
+        try:
+            end_pos = str(int(start_pos)+1)
+        except ValueError:
+            print(data)
+            sys.exit(2)
 
     # resolve end pos from ref allele length if empty string
     if end_pos == "":

--- a/standardize_mutation_data.py
+++ b/standardize_mutation_data.py
@@ -1321,8 +1321,8 @@ def resolve_vcf_variant_allele_data(vcf_data, maf_data):
                 alt_allele = alt_allele[1:]
 
             # fix start position value
-            if start_pos != "":
-                start_pos = str(int(start_pos) + 1)
+            # if start_pos != "":
+            #     start_pos = str(int(start_pos) + 1)
 
         # resolve variant type, end position, and variant class
         variant_type = resolve_vcf_variant_type(ref_allele, alt_allele)

--- a/standardize_mutation_data.py
+++ b/standardize_mutation_data.py
@@ -457,13 +457,13 @@ def resolve_end_position(data, start_pos, variant_type, ref_allele):
         if column in data.keys():
             end_pos = process_datum(data[column])
             break
-    # if insertion then end pos is start pos + 1
-    if variant_type == "INS" or ref_allele == "-":
-        try:
-            end_pos = str(int(start_pos)+1)
-        except ValueError:
-            print(data)
-            sys.exit(2)
+    # # if insertion then end pos is start pos + 1
+    # if variant_type == "INS" or ref_allele == "-":
+    #     try:
+    #         end_pos = str(int(start_pos)+1)
+    #     except ValueError:
+    #         print(data)
+    #         sys.exit(2)
 
     # resolve end pos from ref allele length if empty string
     if end_pos == "":


### PR DESCRIPTION
* After confirmation with UHN, we are going to remove this logic, indels from vcf are shifted by one nucleotide and start positions are incremented by one.
* Keeping this logic: if the variant is an insertion then the end position is start position+1

I also provided an example input and output and was confirmed by UHN
