### PR TITLE
[GEN-1163] hotfix annotation tools

### DIFF
--- a/annotation_suite_wrapper.sh
+++ b/annotation_suite_wrapper.sh
@@ -20,7 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-source annotation-tools/annotation_suite_functions.sh
+current_dir=$(dirname $(readlink -f $0))
+source "$current_dir"/annotation_suite_functions.sh
 
 # verify python3 and java installations
 command -v python3 >/dev/null 2>&1 || {

--- a/annotation_suite_wrapper.sh
+++ b/annotation_suite_wrapper.sh
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-source ../annotation-tools/annotation_suite_functions.sh
+source annotation-tools/annotation_suite_functions.sh
 
 # verify python3 and java installations
 command -v python3 >/dev/null 2>&1 || {


### PR DESCRIPTION
**Purpose:** This PR fix uses a universal way to get the current directory of the script. Mainly needed because our nextflow script calls the python script (inside Genie repo) that calls the bash script inside the `annotation-tools` repo

**Testing:** 
- Tested locally on genie pipeline
- Tested on nf-genie using rebuilt docker image that contains this fix, and process_maf runs all the way through