### PR TITLE
[GEN-1954] Add Transcript_Exon as additional maf column

### DIFF
--- a/standardize_mutation_data.py
+++ b/standardize_mutation_data.py
@@ -787,6 +787,7 @@ def create_maf_record_from_maf(filename, data, center_name, sequence_source):
     maf_data["Center"] = resolve_center_name(data, center_name)
     maf_data["Sequencer"] = resolve_sequencer(data)
     maf_data["FILTER"] = data.get("FILTER", "")
+    maf_data["Transcript_Exon"] = data.get("Transcript_Exon", "")
 
     # if the verification status if "Verified" then the validation status can be set to "Valid"
     if maf_data["Verification_Status"] == "Verified":

--- a/standardize_mutation_data.py
+++ b/standardize_mutation_data.py
@@ -86,7 +86,8 @@ MAF_HEADER = [
     "gnomAD_FIN_AF",
     "gnomAD_NFE_AF",
     "gnomAD_OTH_AF",
-    "gnomAD_SAS_AF"
+    "gnomAD_SAS_AF",
+    "Transcript_Exon"
 ]
 
 VCF_FIXED_HEADER_NON_CASE_IDS = [


### PR DESCRIPTION
**Problem:** We are adding in a new maf column `Transcript_Exon` that's not required AND not provided by Genome Nexus annotation to go through our processing pipeline. This column currently gets removed when going through this `annotation-tools` repo.

**Solution:** We need to adjust the current expected maf header to include the new column. We also need to extract the original values of the column in the new maf file. This happens in `standardize_mutation_data.py` step.

**Testing:** Tested on [example maf dataset](https://www.synapse.org/Synapse:syn52955202.19) with `Transcript_Exon` values filled out.
1. Values going into this annotation-tools repo:
<img width="1376" alt="image" src="https://github.com/user-attachments/assets/251e2790-4010-45e9-98c4-aaf40a9266ce" />

2. Values are preserved after `standardize_mutation_data` step
<img width="1370" alt="image" src="https://github.com/user-attachments/assets/0b022e86-5386-4d9f-b01f-4c69fd02d59e" />

3. Values are preserved after genome nexus annotation: 
<img width="1351" alt="image" src="https://github.com/user-attachments/assets/ecd4a3e7-bae2-4d0b-b338-263fe0e88985" />
